### PR TITLE
Load WASM as file instead of embedding it in the JS file

### DIFF
--- a/packages/benchmark/webpack.config.js
+++ b/packages/benchmark/webpack.config.js
@@ -29,7 +29,9 @@ module.exports = {
         ]
     },
     node: {
-        fs: "empty" // mock fs as empty module. Needed for EMCC modules
+        fs: "empty",
+        path: "empty",
+        Buffer: false
     },
     devServer: {
         compress: true

--- a/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
+++ b/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
@@ -77,7 +77,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -85,10 +89,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -100,7 +107,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -297,7 +304,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -305,10 +316,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -320,7 +334,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -483,7 +497,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -491,10 +509,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -506,7 +527,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -669,7 +690,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -677,10 +702,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -692,7 +720,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -854,7 +882,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -862,10 +894,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -877,7 +912,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -1039,7 +1074,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -1047,10 +1086,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -1062,7 +1104,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {
@@ -1224,7 +1266,11 @@ function __moduleLoader(wasmUri, options) {
     function loadInstance() {
         var instance;
         var wasmLoaded;
-        if (typeof fetch === \\"function\\") {
+        // browser
+        if (typeof window !== \\"undefined\\") {
+            if (typeof fetch !== \\"function\\") {
+                throw new Error(\\"Your browser does not support the fetch API. Include a fetch polyfill to load the WASM module\\");
+            }
             wasmLoaded = fetch(wasmUri).then(function (response) {
                 if (response.ok) {
                     return response.arrayBuffer();
@@ -1232,10 +1278,13 @@ function __moduleLoader(wasmUri, options) {
                 throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
             });
         }
-        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+        else if (typeof module !== 'undefined' && module.exports) {
             wasmLoaded = new Promise(function (resolve, reject) {
-                var fs = require(\\"fs\\");
-                var path = require(\\"path\\");
+                // trick webpack to not detect the require call. Webpack should not include the required files as we only
+                // want to execute this code if we are in node and use the fetch api in the browser.
+                var req = module[\\"require\\"];
+                var fs = req(\\"fs\\");
+                var path = req(\\"path\\");
                 fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
                     if (error) {
                         reject(error);
@@ -1247,7 +1296,7 @@ function __moduleLoader(wasmUri, options) {
             });
         }
         else {
-            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+            throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
         return wasmLoaded.then(function (buffer) {
             return WebAssembly.instantiate(buffer, {

--- a/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
+++ b/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
@@ -29,7 +29,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -76,53 +76,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -146,10 +174,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 141, 128, 128, 128, 0, 1, 9, 95, 105, 115, 84, 114, 117, 116, 104, 121, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 139, 128, 128, 128, 0, 1, 133, 128, 128, 128, 0, 0, 32, 0, 69, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./istruthy.wasm\\", {
     totalStack: 532480,
     initialMemory: 16777216,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: false
 });
@@ -221,7 +249,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -268,53 +296,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -338,10 +394,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 532480,
     initialMemory: 16777216,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: true
 });
@@ -379,7 +435,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -426,53 +482,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -496,10 +580,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 532480,
     initialMemory: 16777216,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: true
 });
@@ -537,7 +621,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -584,53 +668,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -654,7 +766,7 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 532480,
     initialMemory: 16777216,
     globalBase: 4000,
@@ -694,7 +806,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -741,53 +853,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -811,10 +951,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 160, 1, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 532480,
     initialMemory: 10485760,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: false
 });
@@ -851,7 +991,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -898,53 +1038,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -968,10 +1136,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 1048576,
     initialMemory: 16777216,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: false
 });
@@ -1008,7 +1176,7 @@ var Allocation;
      */
     Allocation[Allocation[\\"NONE\\"] = 4] = \\"NONE\\";
 })(Allocation || (Allocation = {}));
-function __moduleLoader(bytes, options) {
+function __moduleLoader(wasmUri, options) {
     var TOTAL_STACK = options.totalStack;
     var INITIAL_MEMORY = options.initialMemory;
     var totalMemory = INITIAL_MEMORY;
@@ -1055,53 +1223,81 @@ function __moduleLoader(bytes, options) {
     }
     function loadInstance() {
         var instance;
-        return WebAssembly.instantiate(bytes.buffer, {
-            env: {
-                memory: memory,
-                STACKTOP: STACK_TOP,
-                __dso_handle: 0,
-                \\"__cxa_allocate_exception\\": function () {
-                    console.log(\\"__cxa_allocate_exception\\", arguments);
-                },
-                \\"__cxa_throw\\": function () {
-                    console.log(\\"__cxa_throw\\", arguments);
-                },
-                \\"__cxa_find_matching_catch_2\\": function () {
-                    console.log(\\"__cxa_find_matching_catch_2\\", arguments);
-                },
-                \\"__cxa_free_exception\\": function () {
-                    console.log(\\"__cxa_free_exception\\", arguments);
-                },
-                \\"__resumeException\\": function () {
-                    console.log(\\"__resumeException\\", arguments);
-                },
-                \\"__cxa_atexit\\": function () {
-                    console.log(\\"__cxa_atexit\\", arguments);
-                },
-                \\"pow\\": Math.pow,
-                \\"fmod\\": function frem(x, y) {
-                    return x % y;
-                },
-                \\"abort\\": function (what) {
-                    console.error(\\"Abort WASM for reason: \\" + what);
-                },
-                \\"invoke_ii\\": function (index, a1) {
-                    return instance.exports.dynCall_ii(index, a1);
-                },
-                \\"invoke_iii\\": function (index, a1, a2) {
-                    return instance.exports.dynCall_iii(index, a1, a2);
-                },
-                \\"invoke_iiii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_iiii(index, a1, a2, a3);
-                },
-                \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
-                    return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
-                },
-                \\"invoke_viii\\": function (index, a1, a2, a3) {
-                    return instance.exports.dynCall_viii(index, a1, a2, a3);
-                },
-                \\"sbrk\\": sbrk
-            }
+        var wasmLoaded;
+        if (typeof fetch === \\"function\\") {
+            wasmLoaded = fetch(wasmUri).then(function (response) {
+                if (response.ok) {
+                    return response.arrayBuffer();
+                }
+                throw new Error(\\"Failed to load WASM module from \\" + wasmUri + \\" (\\" + response.statusText + \\").\\");
+            });
+        }
+        else if (typeof module !== 'undefined' && module.exports && typeof (require) === \\"function\\") {
+            wasmLoaded = new Promise(function (resolve, reject) {
+                var fs = require(\\"fs\\");
+                var path = require(\\"path\\");
+                fs.readFile(path.join(__dirname, wasmUri), function (error, data) {
+                    if (error) {
+                        reject(error);
+                    }
+                    else {
+                        resolve(data.buffer);
+                    }
+                });
+            });
+        }
+        else {
+            throw new Error(\\"Unknown environment, failed to laod WASM module\\");
+        }
+        return wasmLoaded.then(function (buffer) {
+            return WebAssembly.instantiate(buffer, {
+                env: {
+                    memory: memory,
+                    STACKTOP: STACK_TOP,
+                    __dso_handle: 0,
+                    \\"__cxa_allocate_exception\\": function () {
+                        console.log(\\"__cxa_allocate_exception\\", arguments);
+                    },
+                    \\"__cxa_throw\\": function () {
+                        console.log(\\"__cxa_throw\\", arguments);
+                    },
+                    \\"__cxa_find_matching_catch_2\\": function () {
+                        console.log(\\"__cxa_find_matching_catch_2\\", arguments);
+                    },
+                    \\"__cxa_free_exception\\": function () {
+                        console.log(\\"__cxa_free_exception\\", arguments);
+                    },
+                    \\"__resumeException\\": function () {
+                        console.log(\\"__resumeException\\", arguments);
+                    },
+                    \\"__cxa_atexit\\": function () {
+                        console.log(\\"__cxa_atexit\\", arguments);
+                    },
+                    \\"pow\\": Math.pow,
+                    \\"fmod\\": function frem(x, y) {
+                        return x % y;
+                    },
+                    \\"abort\\": function (what) {
+                        console.error(\\"Abort WASM for reason: \\" + what);
+                    },
+                    \\"invoke_ii\\": function (index, a1) {
+                        return instance.exports.dynCall_ii(index, a1);
+                    },
+                    \\"invoke_iii\\": function (index, a1, a2) {
+                        return instance.exports.dynCall_iii(index, a1, a2);
+                    },
+                    \\"invoke_iiii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_iiii(index, a1, a2, a3);
+                    },
+                    \\"invoke_iiiii\\": function (index, a1, a2, a3, a4) {
+                        return instance.exports.dynCall_iiiii(index, a1, a2, a3, a4);
+                    },
+                    \\"invoke_viii\\": function (index, a1, a2, a3) {
+                        return instance.exports.dynCall_viii(index, a1, a2, a3);
+                    },
+                    \\"sbrk\\": sbrk
+                }
+            });
         }).then(function (result) { return instance = result.instance; });
     }
     var speedyJsGc;
@@ -1125,10 +1321,10 @@ function __moduleLoader(bytes, options) {
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-const loadWasmModule_1 = __moduleLoader(Uint8Array.from([0, 97, 115, 109, 1, 0, 0, 0, 1, 134, 128, 128, 128, 0, 1, 96, 1, 127, 1, 127, 2, 144, 128, 128, 128, 0, 1, 3, 101, 110, 118, 6, 109, 101, 109, 111, 114, 121, 2, 0, 128, 2, 3, 130, 128, 128, 128, 0, 1, 0, 4, 132, 128, 128, 128, 0, 1, 112, 0, 0, 7, 136, 128, 128, 128, 0, 1, 4, 95, 102, 105, 98, 0, 0, 9, 129, 128, 128, 128, 0, 0, 10, 195, 128, 128, 128, 0, 1, 189, 128, 128, 128, 0, 1, 1, 127, 2, 127, 65, 1, 33, 1, 2, 64, 32, 0, 65, 3, 72, 13, 0, 65, 1, 33, 1, 32, 0, 65, 1, 106, 33, 0, 3, 64, 32, 0, 65, 125, 106, 16, 0, 32, 1, 106, 33, 1, 32, 0, 65, 127, 106, 34, 0, 65, 3, 74, 13, 0, 11, 11, 32, 1, 11, 11]), {
+const loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", {
     totalStack: 532480,
     initialMemory: 16777216,
-    globalBase: 1024,
+    globalBase: 8,
     staticBump: 8,
     exposeGc: false
 });

--- a/packages/compiler/cli.ts
+++ b/packages/compiler/cli.ts
@@ -51,7 +51,7 @@ function parseCommandLine(): CommandLineArguments {
         .option("--binaryen-opt", "Optimize using Binaryen opt")
         .option("--expose-gc", "Exposes the speedy js garbage collector in the module as speedyJsGc")
         .option("--export-gc", "Exposes and exports the speedy js garbage collector as the symbol speedyJsGc")
-        .option("--disable-heap-nuke-on-exit", "Disables nuking of the heap prior to the exit of the entry function (its your responsible to call the gc in this case!)")
+        .option("--disable-heap-nuke-on-exit", "Disables nuking of the heap before to the exit of the entry function (it's your responsible for calling the GC in this case!)")
         .option("--optimization-level [value]", "The optimization level to use. One of the following values: '0, 1, 2, 3, s or z'")
         .option("-s --settings [value]", "additional settings", parseSettings, {})
         .parse(process.argv);

--- a/packages/compiler/karma.conf.js
+++ b/packages/compiler/karma.conf.js
@@ -48,7 +48,12 @@ module.exports = function (config) {
                         }
                     }
                 ]
-            }
+            },
+            node: {
+                fs: "empty",
+                path: "empty",
+                Buffer: false
+            },
         },
         webpackMiddleware: {
             stats: {

--- a/packages/compiler/scripts/binaryen-installer.js
+++ b/packages/compiler/scripts/binaryen-installer.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const dependencyUtils = require("./dependency-utils");
 
-const BINARYEN_GIT_URL = "https://github.com/MichaReiser/binaryen.git";
+const BINARYEN_GIT_URL = "https://github.com/WebAssembly/binaryen.git";
 
 function buildBinaryen(directory) {
     console.log("Build Binaryen");
@@ -11,7 +11,6 @@ function buildBinaryen(directory) {
     const binaryenBuildDirectory = binaryenDirectory;
 
     dependencyUtils.gitCloneOrPull(BINARYEN_GIT_URL, binaryenDirectory);
-    dependencyUtils.exec("git -C %s checkout select-self-assignment-to-branch", binaryenDirectory);
 
     if (!fs.existsSync(binaryenBuildDirectory)) {
         fs.mkdirSync(binaryenBuildDirectory);

--- a/packages/compiler/src/code-generation/per-file/llvm-emit-source-file-rewriter.ts
+++ b/packages/compiler/src/code-generation/per-file/llvm-emit-source-file-rewriter.ts
@@ -9,7 +9,7 @@ export class NoopSourceFileRewriter implements PerFileSourceFileRewirter {
     setWastMetaData(metadata: WastMetaData): void {
         // noop
     }
-    setWasmOutput(output: Buffer): void {
+    setWasmUrl(wasmUrl: string): void {
         // noop
     }
 

--- a/packages/compiler/src/code-generation/per-file/per-file-code-generator.ts
+++ b/packages/compiler/src/code-generation/per-file/per-file-code-generator.ts
@@ -286,12 +286,14 @@ class BinaryenOptTransformationStep implements TransformationStep {
 }
 
 class WasmToAsTransformationStep implements TransformationStep {
-    transform(inputFileName: string, { buildDirectory, plainFileName, sourceFileRewriter}: TransformationContext): string {
+    transform(inputFileName: string, { buildDirectory, plainFileName, sourceFileRewriter, sourceFile, codeGenerationContext}: TransformationContext): string {
         const wasmFileName = buildDirectory.getTempFileName(`${plainFileName}.wasm`);
         wasmAs(inputFileName, wasmFileName);
 
-        const buffer = fs.readFileSync(wasmFileName);
-        sourceFileRewriter.setWasmOutput(buffer);
+        const wasmFileWriter = codeGenerationContext.compilationContext.compilerOptions.wasmFileWriter;
+        const finalWasmFileName = getOutputFileName(sourceFile, codeGenerationContext);
+        const wasmFetchExpression = wasmFileWriter.writeWasmFile(finalWasmFileName, fs.readFileSync(wasmFileName), codeGenerationContext);
+        sourceFileRewriter.setWasmUrl(wasmFetchExpression);
 
         return wasmFileName;
     }

--- a/packages/compiler/src/code-generation/per-file/per-file-source-file-rewriter.ts
+++ b/packages/compiler/src/code-generation/per-file/per-file-source-file-rewriter.ts
@@ -13,10 +13,10 @@ export interface PerFileSourceFileRewirter {
     setWastMetaData(metadata: WastMetaData): void;
 
     /**
-     * Sets the output for this source file
-     * @param output the output
+     * Sets the url to the wasm file
+     * @param wasmUrl the url to the wasm file
      */
-    setWasmOutput(output: Buffer): void;
+    setWasmUrl(wasmUrl: string): void;
 
     /**
      * Rewrites a SpeedyJS entry function

--- a/packages/compiler/src/default-wasm-file-writer.ts
+++ b/packages/compiler/src/default-wasm-file-writer.ts
@@ -1,0 +1,12 @@
+import * as path from "path";
+import {WasmFileWriter} from "./wasm-file-writer";
+import {CodeGenerationContext} from "./code-generation/code-generation-context";
+
+export class DefaultWasmFileWriter implements WasmFileWriter {
+    writeWasmFile(fileName: string, content: Buffer, codeGenerationContext: CodeGenerationContext): string {
+        // Parameter can also be a buffer. If string is used, then it gets mixed up with the encoding.
+        codeGenerationContext.compilationContext.compilerHost.writeFile(fileName, content as any, false);
+
+        return `./${path.basename(fileName)}`;
+    }
+}

--- a/packages/compiler/src/external-tools/binaryen-opt.ts
+++ b/packages/compiler/src/external-tools/binaryen-opt.ts
@@ -14,6 +14,6 @@ const EXECUTABLE_NAME = "wasm-opt";
 export function wasmOpt(wastFile: string, outputFile: string): string {
     LOG(`Optimize ${wastFile}`);
 
-    LOG(execBinaryen(EXECUTABLE_NAME, `"${wastFile}" -o "${outputFile}" -O3 --emit-text --assignment-of-select-to-branch --vacuum`));
+    LOG(execBinaryen(EXECUTABLE_NAME, `"${wastFile}" -o "${outputFile}" --post-emscripten --emit-text`));
     return outputFile;
 }

--- a/packages/compiler/src/in-memory-compiler.ts
+++ b/packages/compiler/src/in-memory-compiler.ts
@@ -87,11 +87,11 @@ export function compileSourceCode(sourceCode: string, inputFileName: string, opt
             if (name.endsWith(".map")) {
                 assert(sourceMapText === undefined, `Unexpected multiple source map outputs for the file '${name}'`);
                 sourceMapText = text;
-            }
-            else {
+            } else if (name.endsWith(".js")) {
                 assert(outputText === undefined, `Unexpected multiple outputs for the file: '${name}'`);
                 outputText = text;
             }
+            // not interested in wasm file
         }
     };
 

--- a/packages/compiler/src/speedyjs-compiler-options.ts
+++ b/packages/compiler/src/speedyjs-compiler-options.ts
@@ -1,4 +1,6 @@
 import {CompilerOptions} from "typescript";
+import {WasmFileWriter} from "./wasm-file-writer";
+import {DefaultWasmFileWriter} from "./default-wasm-file-writer";
 
 export type OptimizationLevel = "0" | "1" | "2" | "3" | "z" | "s";
 
@@ -6,6 +8,7 @@ export type OptimizationLevel = "0" | "1" | "2" | "3" | "z" | "s";
  * Speedy JS Compiler Options
  */
 export interface SpeedyJSCompilerOptions extends CompilerOptions {
+    [option: string]: any;
 
     /**
      * Indicator if the emitted code and runtime should be memory safe or unsafe (truthy)
@@ -81,6 +84,11 @@ export interface SpeedyJSCompilerOptions extends CompilerOptions {
      * @default "3"
      */
     optimizationLevel: OptimizationLevel;
+
+    /**
+     * The implementation that writes the wasm file
+     */
+    wasmFileWriter: WasmFileWriter;
 }
 
 /**
@@ -103,12 +111,13 @@ export function initializeCompilerOptions(compilerOptions: UninitializedSpeedyJS
         binaryenOpt: false,
         initialMemory: 16 * 1024 * 1024,
         totalStack: 5 * 1024 * 104,
-        globalBase: 1024,
+        globalBase: 8,
         saveBc: false,
         disableHeapNukeOnExit: false,
         exposeGc: false,
         exportGc: false,
-        optimizationLevel: "2"
+        optimizationLevel: "2",
+        wasmFileWriter: new DefaultWasmFileWriter()
     };
 
     for (const key of Object.keys(defaults)) {
@@ -118,6 +127,7 @@ export function initializeCompilerOptions(compilerOptions: UninitializedSpeedyJS
     compilerOptions.strictNullChecks = true;
     compilerOptions.noImplicitAny = true; // speedy js cannot handle any
     compilerOptions.noImplicitReturns = true;
+    compilerOptions.lib = compilerOptions.lib || ["lib.es2015.d.ts" ];
 
     return compilerOptions as SpeedyJSCompilerOptions;
 }

--- a/packages/compiler/src/wasm-file-writer.ts
+++ b/packages/compiler/src/wasm-file-writer.ts
@@ -1,0 +1,20 @@
+import {CodeGenerationContext} from "./code-generation/code-generation-context";
+
+/**
+ * Writes the WASM file output and generates the URL used to fetch the WASM file
+ *
+ * E.g. when no bundler is used, then the url to load the wasm file is just the relative path of the
+ * wasm file to the js file. However, if webpack, or another bundler, is used then the URL needs to be relative to the output
+ * bundle and not to the javascript file.
+ */
+export interface WasmFileWriter {
+
+    /**
+     * Writes the wasm file and returns a url that can be used to load the file
+     * @param fileName the name of the wasm file
+     * @param content the Wasm Module content
+     * @param codeGenerationContext the code generation context
+     * @returns the url to the file
+     */
+    writeWasmFile(fileName: string, content: Buffer, codeGenerationContext: CodeGenerationContext): string;
+}


### PR DESCRIPTION
Emit the WASM file as binary and load it in JS using fetch or fs.readFile
instead of embedding it into the JS file. This reduces the JS file
size significantly.
