### PR TITLE
Initialize the loadWasmModule Variable in the first statement of the …

### DIFF
--- a/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
+++ b/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
@@ -4,9 +4,9 @@ exports[`Transformation casts the return value for boolean functions to a bool v
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -71,7 +71,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -93,7 +93,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -113,7 +113,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -121,7 +121,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -141,7 +141,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -151,7 +151,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -168,9 +168,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -196,7 +198,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -216,10 +218,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -231,7 +234,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -399,18 +402,17 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function isTruthy(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._isTruthy(value) === 1; loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./istruthy.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] }, \\"i1\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./istruthy.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+function isTruthy(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i1\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] }, \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._isTruthy(value) === 1; loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -418,9 +420,9 @@ exports[`Transformation converts Array and Objects to WASM arrays and Objects 1`
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -485,7 +487,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -507,7 +509,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -527,7 +529,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -535,7 +537,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -555,7 +557,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -565,7 +567,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -582,9 +584,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -610,7 +614,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -630,10 +634,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -645,7 +650,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -813,20 +818,19 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
+var loadWasmModule_1 = __moduleLoader(\\"./converts-arrays-and-object.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1228, \\"exposeGc\\": false });
 class Test {
 }
-function update(instance, values) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var argumentObjects_1 = new Map(); var result_1 = instance_1.exports._update(loadWasmModule_1.toWASM(instance, \\"Test\\", argumentObjects_1), loadWasmModule_1.toWASM(values, \\"Array<double>\\", argumentObjects_1)); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./converts-arrays-and-object.wasm\\", { \\"Array<double>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"double\\"] }, \\"double\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] }, \\"Test\\": { \\"primitive\\": false, \\"fields\\": [{ \\"name\\": \\"updated\\", \\"type\\": \\"i1\\" }, { \\"name\\": \\"value\\", \\"type\\": \\"double\\" }], \\"constructor\\": Test, \\"typeArguments\\": [] }, \\"i1\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1228, \\"exposeGc\\": false });
+function update(instance, values) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"double\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] }, \\"Array<double>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"double\\"] }, \\"Test\\": { \\"primitive\\": false, \\"fields\\": [{ \\"name\\": \\"updated\\", \\"type\\": \\"i1\\" }, { \\"name\\": \\"value\\", \\"type\\": \\"double\\" }], \\"constructor\\": Test, \\"typeArguments\\": [] }, \\"i1\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var argumentObjects_1 = new Map(); var result_1 = instance_1.exports._update(loadWasmModule_1.toWASM(instance, \\"Test\\", types_1, argumentObjects_1), loadWasmModule_1.toWASM(values, \\"Array<double>\\", types_1, argumentObjects_1)); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -834,9 +838,9 @@ exports[`Transformation converts a returned WASM array to a JS array 1`] = `
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -901,7 +905,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -923,7 +927,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -943,7 +947,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -951,7 +955,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -971,7 +975,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -981,7 +985,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -998,9 +1002,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -1026,7 +1032,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -1046,10 +1052,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -1061,7 +1068,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -1229,18 +1236,17 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function update() { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = loadWasmModule_1.toJSObject(instance_1.exports._update(), \\"Array<i32>\\"); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./converts-returned-arrays.wasm\\", { \\"Array<i32>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"i32\\"] }, \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1368, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./converts-returned-arrays.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1368, \\"exposeGc\\": false });
+function update() { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"Array<i32>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"i32\\"] }, \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = loadWasmModule_1.toJSObject(instance_1.exports._update(), \\"Array<i32>\\", types_1); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -1248,9 +1254,9 @@ exports[`Transformation converts the returned WASM Object to a JS Object 1`] = `
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -1315,7 +1321,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -1337,7 +1343,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -1357,7 +1363,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -1365,7 +1371,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -1385,7 +1391,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -1395,7 +1401,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -1412,9 +1418,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -1440,7 +1448,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -1460,10 +1468,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -1475,7 +1484,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -1643,20 +1652,19 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
+var loadWasmModule_1 = __moduleLoader(\\"./converts-arrays-and-object.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1228, \\"exposeGc\\": false });
 class Test {
 }
-function update(values) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var argumentObjects_1 = new Map(); var result_1 = instance_1.exports._update(loadWasmModule_1.toWASM(values, \\"Array<double>\\", argumentObjects_1)); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./converts-arrays-and-object.wasm\\", { \\"Array<double>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"double\\"] }, \\"double\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 1228, \\"exposeGc\\": false });
+function update(values) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"double\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] }, \\"Array<double>\\": { \\"primitive\\": false, \\"fields\\": [], \\"constructor\\": Array, \\"typeArguments\\": [\\"double\\"] } }; var argumentObjects_1 = new Map(); var result_1 = instance_1.exports._update(loadWasmModule_1.toWASM(values, \\"Array<double>\\", types_1, argumentObjects_1)); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -1699,9 +1707,9 @@ exports[`Transformation exports the gc function if exportGc is set 1`] = `
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -1766,7 +1774,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -1788,7 +1796,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -1808,7 +1816,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -1816,7 +1824,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -1836,7 +1844,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -1846,7 +1854,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -1863,9 +1871,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -1891,7 +1901,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -1911,10 +1921,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -1926,7 +1937,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -2094,19 +2105,18 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": true });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": true });
 export const speedyJsGc = loadWasmModule_1.gc;
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -2114,9 +2124,9 @@ exports[`Transformation exposes the gc function if exposeGc is set 1`] = `
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -2181,7 +2191,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -2203,7 +2213,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -2223,7 +2233,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -2231,7 +2241,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -2251,7 +2261,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -2261,7 +2271,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -2278,9 +2288,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -2306,7 +2318,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -2326,10 +2338,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -2341,7 +2354,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -2509,19 +2522,18 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": true });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": true });
 const speedyJsGc = loadWasmModule_1.gc;
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -2529,9 +2541,9 @@ exports[`Transformation passes the configured global base to the module loader 1
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -2596,7 +2608,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -2618,7 +2630,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -2638,7 +2650,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -2646,7 +2658,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -2666,7 +2678,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -2676,7 +2688,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -2693,9 +2705,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -2721,7 +2735,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -2741,10 +2755,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -2756,7 +2771,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -2924,18 +2939,17 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 4000, \\"staticBump\\": 8, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 4000, \\"staticBump\\": 8, \\"exposeGc\\": false });
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -2943,9 +2957,9 @@ exports[`Transformation passes the configured initial memory to the module loade
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -3010,7 +3024,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3032,7 +3046,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -3052,7 +3066,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -3060,7 +3074,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3080,7 +3094,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -3090,7 +3104,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -3107,9 +3121,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -3135,7 +3151,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -3155,10 +3171,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -3170,7 +3187,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -3338,18 +3355,17 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 10485760, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 10485760, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -3357,9 +3373,9 @@ exports[`Transformation passes the configured total stack to the module loader 1
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -3424,7 +3440,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3446,7 +3462,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -3466,7 +3482,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -3474,7 +3490,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3494,7 +3510,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -3504,7 +3520,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -3521,9 +3537,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -3549,7 +3567,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -3569,10 +3587,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -3584,7 +3603,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -3752,18 +3771,17 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 1048576, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 1048576, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;
 
@@ -3771,9 +3789,9 @@ exports[`Transformation rewrites the speedyjs function to call into the web asse
 "/**
  * This file includes a single statement, the function declaration of the getWasmModuleFactory. This function is used in the
  * speedyjs-transformer to generate the code to load the wasm module.
- * Part of this source code has been taken from https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
+ * The code is inspired by https://github.com/kripken/emscripten/blob/incoming/src/runtime.js
  */
-function __moduleLoader(wasmUri, types, options) {
+function __moduleLoader(wasmUri, options) {
     var PTR_SIZE = 4;
     var PTR_SHIFT = Math.log2(PTR_SIZE);
     function sizeOf(type) {
@@ -3838,7 +3856,7 @@ function __moduleLoader(wasmUri, types, options) {
             return alignMemory(memo + fieldSize, fieldSize);
         }, 0);
     }
-    function jsToWasm(jsValue, typeName, objectReferences) {
+    function jsToWasm(jsValue, typeName, types, objectReferences) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3860,7 +3878,7 @@ function __moduleLoader(wasmUri, types, options) {
             if (!Array.isArray(jsValue)) {
                 throw new Error(\\"Expected argument of type Array\\");
             }
-            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], objectReferences).ptr;
+            ptr = RuntimeArray.from(jsValue, type.typeArguments[0], types, objectReferences).ptr;
         }
         else {
             // Object
@@ -3880,7 +3898,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 offset = alignMemory(offset, fieldSize);
-                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, objectReferences), field.type);
+                setHeapValue(objPtr + offset, jsToWasm(jsValue[field.name], field.type, types, objectReferences), field.type);
                 offset += fieldSize;
             }
             ptr = objPtr;
@@ -3888,7 +3906,7 @@ function __moduleLoader(wasmUri, types, options) {
         objectReferences.set(jsValue, ptr);
         return ptr;
     }
-    function wasmToJs(wasmValue, typeName, returnedObjects) {
+    function wasmToJs(wasmValue, typeName, types, returnedObjects) {
         var type = types[typeName];
         if (!type) {
             throw new Error(\\"Unknown type \\" + typeName);
@@ -3908,7 +3926,7 @@ function __moduleLoader(wasmUri, types, options) {
             return undefined;
         }
         else if (type.constructor === Array) {
-            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(returnedObjects);
+            objectReference = new RuntimeArray(ptr, type.typeArguments[0]).toArray(types, returnedObjects);
         }
         else {
             // Object
@@ -3918,7 +3936,7 @@ function __moduleLoader(wasmUri, types, options) {
                 var field = _a[_i];
                 var fieldSize = sizeOf(field.type);
                 memoryOffset = alignMemory(memoryOffset, fieldSize);
-                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, returnedObjects);
+                obj[field.name] = wasmToJs(getHeapValue(memoryOffset, field.type), field.type, types, returnedObjects);
                 memoryOffset += fieldSize;
             }
             objectReference = obj;
@@ -3935,9 +3953,11 @@ function __moduleLoader(wasmUri, types, options) {
          * Allocates a Speedy.js array for the given JS array
          * @param native the js array
          * @param elementType the element type
+         * @param types the reflection information of the used types
+         * @param objectReferences map from JS to WASM pointers of already deserialized objects
          * @return {RuntimeArray} the Speedy.js Array
          */
-        RuntimeArray.from = function (native, elementType, objectReferences) {
+        RuntimeArray.from = function (native, elementType, types, objectReferences) {
             // begin, back, capacity
             var size = PTR_SIZE * 2 + sizeOf(\\"i32\\");
             var arrayPtr = malloc(size);
@@ -3963,7 +3983,7 @@ function __moduleLoader(wasmUri, types, options) {
                     heap64.set(native, begin >> 3);
                     break;
                 default:
-                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, objectReferences); }), begin >> PTR_SHIFT);
+                    heapPtr.set(Int32Array.from(native, function (object) { return jsToWasm(object, elementType, types, objectReferences); }), begin >> PTR_SHIFT);
             }
             return new RuntimeArray(arrayPtr, elementType);
         };
@@ -3983,10 +4003,11 @@ function __moduleLoader(wasmUri, types, options) {
         });
         /**
          * Converts a Speedy.js array to a native JS array
+         * @param types the reflection information of the object types
          * @param objectReferences map from WASM pointers to the deserialized JS objects
          * @return {Array} the native JS Array
          */
-        RuntimeArray.prototype.toArray = function (objectReferences) {
+        RuntimeArray.prototype.toArray = function (types, objectReferences) {
             var _this = this;
             switch (this.elementType) {
                 case \\"i1\\":
@@ -3998,7 +4019,7 @@ function __moduleLoader(wasmUri, types, options) {
                 case \\"double\\":
                     return Array.from(heap64.subarray(this.begin >> 3, this.back >> 3));
                 default:
-                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, objectReferences); });
+                    return Array.from(heapPtr.subarray(this.begin >> PTR_SHIFT, this.back >> PTR_SHIFT), function (objectPtr) { return wasmToJs(objectPtr, _this.elementType, types, objectReferences); });
             }
         };
         return RuntimeArray;
@@ -4166,17 +4187,16 @@ function __moduleLoader(wasmUri, types, options) {
         return loaded;
     };
     loader.gc = gc;
-    loader.toWASM = function (jsObject, objectTypeName, objectReferences) {
-        return jsToWasm(jsObject, objectTypeName, objectReferences);
+    loader.toWASM = function (jsObject, objectTypeName, types, objectReferences) {
+        return jsToWasm(jsObject, objectTypeName, types, objectReferences);
     };
-    loader.toJSObject = function (objectPointer, objectTypeName) {
-        return wasmToJs(objectPointer, objectTypeName, new Map());
+    loader.toJSObject = function (objectPointer, objectTypeName, types) {
+        return wasmToJs(objectPointer, objectTypeName, types, new Map());
     };
     return loader;
 }
 //# sourceMappingURL=get-wasm-module-function.js.map
-let loadWasmModule_1;
-function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
-loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }, { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+var loadWasmModule_1 = __moduleLoader(\\"./fib.wasm\\", { \\"totalStack\\": 532480, \\"initialMemory\\": 16777216, \\"globalBase\\": 8, \\"staticBump\\": 8, \\"exposeGc\\": false });
+function fib(value) { return loadWasmModule_1().then(function instanceLoaded(instance_1) { var types_1 = { \\"i32\\": { \\"primitive\\": true, \\"fields\\": [], \\"constructor\\": undefined, \\"typeArguments\\": [] } }; var result_1 = instance_1.exports._fib(value); loadWasmModule_1.gc(); return result_1; }); }
 "
 `;


### PR DESCRIPTION
…file

This is needed to ensure that the variable is initialized when a WASM
function is called before the body of the script has executed.
In this case, the variable is not initialized when the function is called,
and, therefore, the execution fails.

For example:

```js
async function test() {
  "use speedyjs";
  return 10;
}

test();
```