### PR TITLE
Require the Speedy.js directive for Methods as well

### DIFF
--- a/packages/benchmark/cases/nbody-spdy.ts
+++ b/packages/benchmark/cases/nbody-spdy.ts
@@ -9,7 +9,6 @@ function daysPerYear() {
     return 365.24;
 }
 
-
 class Body {
 
     constructor(
@@ -20,7 +19,9 @@ class Body {
         public vy: number,
         public vz: number,
         public mass: number
-    ) {}
+    ) {
+        "use speedyjs";
+    }
 
     offsetMomentum(px: number, py: number, pz: number) {
         "use speedyjs";
@@ -98,6 +99,8 @@ function Sun(): Body {
 class NBodySystem {
     public bodies: Array< Body >;
     constructor(bodies: Array< Body >) {
+        "use speedyjs";
+
         let px = 0.0;
         let py = 0.0;
         let pz = 0.0;
@@ -114,6 +117,8 @@ class NBodySystem {
     }
 
     advance(dt: number): void {
+        "use speedyjs";
+
         let dx: number,
             dy: number,
             dz: number,
@@ -173,6 +178,8 @@ class NBodySystem {
     }
 
     energy(): number {
+        "use speedyjs";
+        
         let dx: number, dy: number, dz: number, distance: number;
         let ix: number, iy: number, iz: number, vx: number, vy: number, vz: number, bim: number;
         let e = 0.0;

--- a/packages/benchmark/cases/object-passing.ts
+++ b/packages/benchmark/cases/object-passing.ts
@@ -1,9 +1,11 @@
 class Point {
     constructor(private x: number, private y: number) {
-
+        "use speedyjs";
     }
 
     distanceTo(other: Point) {
+        "use speedyjs";
+
         return Math.sqrt(Math.pow(this.x - other.x, 2) + Math.pow(this.y - other.y, 2));
     }
 }

--- a/packages/benchmark/cases/simjs-spdy.ts
+++ b/packages/benchmark/cases/simjs-spdy.ts
@@ -4,7 +4,7 @@
  * The code is licensed as LGPL.
  */
 
-/* 
+/*
  A C-program for MT19937, with initialization improved 2002/1/26.
  Coded by Takuji Nishimura and Makoto Matsumoto.
 
@@ -62,6 +62,8 @@ class Random {
     private lastNormal = NaN;
 
     constructor(seed: int) {
+        "use speedyjs";
+
         this.mt = new Array<int>(this.N); /* the array for the state vector */
         this.mti=this.N+1; /* mti==N+1 means mt[N] is not initialized */
 
@@ -74,6 +76,8 @@ class Random {
     /* key_length is its length */
     /* slight change for C++, 2004/2/26 */
     init_by_array(init_key: int[], key_length: int) {
+        "use speedyjs";
+
         this.init_genrand(19650218);
 
         let i = 1;
@@ -102,6 +106,8 @@ class Random {
 
     /* initializes mt[N] with a seed */
     init_genrand(s: int) {
+        "use speedyjs";
+
         this.mt[0] = s >>> 0;
         for (this.mti=1; this.mti<this.N; ++this.mti) {
             const s = this.mt[this.mti-1] ^ (this.mt[this.mti-1] >>> 30);
@@ -117,6 +123,8 @@ class Random {
 
     /* generates a random number on [0,0xffffffff]-interval */
     genrand_int32(): int {
+        "use speedyjs";
+
         const mag01 = [0x0, this.MATRIX_A];
         /* mag01[x] = x * MATRIX_A  for x=0,1 */
         let y: int;
@@ -165,6 +173,8 @@ class Random {
 
     /* generates a random number on [0,1)-real-interval */
     random(): number {
+        "use speedyjs";
+
         if (this.pythonCompatibility) {
             if (this.skip) {
                 this.genrand_int32();
@@ -195,7 +205,6 @@ class Random {
         return(a*67108864.0+b)*(1.0/9007199254740992.0);
     }
 
-
     /* These real versions are due to Isaku Wada, 2002/01/09 added */
 
 
@@ -203,7 +212,7 @@ class Random {
     exponential(lambda: number) {
         const r = this.random();
         return -Math.log(r) / lambda;
-    };
+    }
 
     gamma(alpha: number, beta: number) {
         /* Based on Python 2.6 source code of random.py.
@@ -260,6 +269,8 @@ class Random {
     }
 
     normal(mu: number, sigma: number) {
+        "use speedyjs";
+
         let z = this.lastNormal;
         this.lastNormal = NaN;
         if (isNaN(z)) {

--- a/packages/benchmark/cases/tspDouble-spdy.ts
+++ b/packages/benchmark/cases/tspDouble-spdy.ts
@@ -1,8 +1,11 @@
 class Point {
     constructor(private x: number, private y: number) {
+        "use speedyjs";
     }
 
     distanceTo(other: Point) {
+        "use speedyjs";
+
         return Math.sqrt(Math.pow(this.x - other.x, 2) + Math.pow(this.y - other.y, 2));
     }
 }

--- a/packages/benchmark/cases/tspInt-spdy.ts
+++ b/packages/benchmark/cases/tspInt-spdy.ts
@@ -1,8 +1,10 @@
 class Point {
     constructor(private x: int, private y: int) {
+        "use speedyjs";
     }
 
     distanceTo(other: Point) {
+        "use speedyjs";
         return Math.sqrt(Math.pow(this.x - other.x, 2) + Math.pow(this.y - other.y, 2));
     }
 }

--- a/packages/compiler/__integrationtests__/classes.spec.ts
+++ b/packages/compiler/__integrationtests__/classes.spec.ts
@@ -8,6 +8,8 @@ class ClassWithConstructor {
     y: number;
 
     constructor(x: number, y: number) {
+        "use speedyjs";
+
         this.x = x;
         this.y = y;
     }
@@ -18,11 +20,15 @@ class ClassWithMethod {
     y: number;
 
     constructor(x: number, y: number) {
+        "use speedyjs";
+
         this.x = x;
         this.y = y;
     }
 
     distanceTo(other: ClassWithMethod) {
+        "use speedyjs";
+
         return Math.sqrt(Math.pow(this.x - other.x, 2.0) + Math.pow(this.y - other.y, 2.0));
     }
 }
@@ -31,10 +37,12 @@ class SubtypeWithMethod extends ClassWithMethod {}
 
 class ClassWithArrayField {
     constructor(public points: ClassWithMethod[] = []) {
-
+        "use speedyjs";
     }
 
     totalDistance() {
+        "use speedyjs";
+
         let distance = 0.0;
 
         for (let i = 0; i < this.points.length - 1; ++i) {
@@ -46,7 +54,9 @@ class ClassWithArrayField {
 }
 
 class ClassWithFieldsDeclaredInConstructor {
-    constructor(public x: number, public y: number) {}
+    constructor(public x: number, public y: number) {
+        "use speedyjs";
+    }
 }
 
 class ClassWithFieldsOfDifferentSize {

--- a/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
+++ b/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
@@ -1688,6 +1688,11 @@ exports[`Transformation emits a diagnostic if a non entry speedyjs function is r
 "
 `;
 
+exports[`Transformation emits a diagnostic if a speedy.js function references a regular JavaScript function 1`] = `
+"test.ts(9,17): error TS1000033: The Speedy.js function cannot reference the regular JavaScript function 'regularJavaScriptFunction'. Calling JavaScript functions from Speedy.js is not yet supported. Either remove the function call or make the called function a Speedy.js function by adding the \\"use speedyjs\\" directive.
+"
+`;
+
 exports[`Transformation emits a diagnostic if the entry function has optional parameters 1`] = `
 "test.ts(2,51): error TS100011: Optional parameters or variadic parameters are not supported for SpeedyJS entry functions.
 "

--- a/packages/compiler/__tests__/code-generation/__snapshots__/classes.spec.ts.snap
+++ b/packages/compiler/__tests__/code-generation/__snapshots__/classes.spec.ts.snap
@@ -604,7 +604,7 @@ attributes #0 = { alwaysinline nounwind readnone }
 `;
 
 exports[`Classes class-with-static-method-error 1`] = `
-"__tests__/code-generation/cases/classes/class-with-static-method-error.ts(14,11): error TS1000026: Static methods and properties are not yet supported.
+"__tests__/code-generation/cases/classes/class-with-static-method-error.ts(17,11): error TS1000026: Static methods and properties are not yet supported.
 "
 `;
 

--- a/packages/compiler/__tests__/code-generation/cases/call-expression/array-passing-function-call.ts
+++ b/packages/compiler/__tests__/code-generation/cases/call-expression/array-passing-function-call.ts
@@ -6,5 +6,7 @@ async function passesArray() {
 }
 
 function arrayLength(array: int[]) {
+    "use speedyjs";
+
     return array.length;
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/class-inheritance-error.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/class-inheritance-error.ts
@@ -4,6 +4,8 @@ class Parent {
 
 class Child extends Parent {
     age() {
+        "use speedyjs";
+
         return 10;
     }
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/class-only-with-methods.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/class-only-with-methods.ts
@@ -1,5 +1,7 @@
 class ClassOnlyWithMethods {
     add(x: number, y: number) {
+        "use speedyjs";
+
         return x + y;
     }
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/class-with-methods.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/class-with-methods.ts
@@ -3,11 +3,15 @@ export class Point {
     y: number;
 
     constructor(x: number, y: number) {
+        "use speedyjs";
+
         this.x = x;
         this.y = y;
     }
 
     distanceTo(to: Point) {
+        "use speedyjs";
+
         return Math.sqrt(Math.pow(this.x - to.x, 2.0) + Math.pow(this.y - to.y, 2.0));
     }
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/class-with-static-method-error.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/class-with-static-method-error.ts
@@ -1,9 +1,12 @@
 class ClassWithStaticMethod {
     static lastId = 0;
     private constructor(public id: int) {
+        "use speedyjs";
     }
 
     static create() {
+        "use speedyjs";
+
         return new ClassWithStaticMethod(++ClassWithStaticMethod.lastId);
     }
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/generic-class-error.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/generic-class-error.ts
@@ -1,9 +1,10 @@
 class Node<T> {
     constructor(private value: T, private next?: Node<T>) {
-
+        "use speedyjs";
     }
 
     length(): int {
+        "use speedyjs";
         return 1 + (this.next ? this.next.length() : 0);
     }
 }

--- a/packages/compiler/__tests__/code-generation/cases/classes/returning-this.ts
+++ b/packages/compiler/__tests__/code-generation/cases/classes/returning-this.ts
@@ -2,6 +2,8 @@ class TestBuilder {
     _size: number;
 
     size(value: number) {
+        "use speedyjs";
+
         this._size = value;
         return this;
     }

--- a/packages/compiler/__tests__/code-generation/cases/use-cases/tsp.ts
+++ b/packages/compiler/__tests__/code-generation/cases/use-cases/tsp.ts
@@ -1,8 +1,11 @@
 class Point {
     constructor(private x: int, private y: int) {
+        "use speedyjs";
     }
 
     distanceTo(other: Point) {
+        "use speedyjs";
+
         return Math.sqrt(Math.pow(this.x - other.x as number, 2.0) + Math.pow(this.y - other.y as number, 2.0));
     }
 }

--- a/packages/compiler/src/code-generation-diagnostic.ts
+++ b/packages/compiler/src/code-generation-diagnostic.ts
@@ -91,6 +91,10 @@ export class CodeGenerationDiagnostic extends Error {
         return CodeGenerationDiagnostic.createException(identifier, diagnostics.ReferenceToNonEntrySpeedyJSFunctionFromJS, speedyJSFunctionSymbol.name);
     }
 
+    static refereneToNonSpeedyJSFunctionFromSpeedyJS(identifier: ts.Identifier, nonSpeedyJsFunctionSymbol: ts.Symbol) {
+        return CodeGenerationDiagnostic.createException(identifier, diagnostics.ReferenceToNonSpeedyJSFunctionFromSpeedyJS, nonSpeedyJsFunctionSymbol.name);
+    }
+
     static overloadedEntryFunctionNotSupported(fun: ts.FunctionLikeDeclaration) {
         return CodeGenerationDiagnostic.createException(fun, diagnostics.OverloadedEntryFunctionNotSupported);
     }
@@ -337,5 +341,9 @@ const diagnostics = {
     UnsupportedClassInheritance: {
         message: "Class inheritance is not yet supported.",
         code: 1000032
+    },
+    ReferenceToNonSpeedyJSFunctionFromSpeedyJS: {
+        message: "The Speedy.js function cannot reference the regular JavaScript function '%s'. Calling JavaScript functions from Speedy.js is not yet supported. Either remove the function call or make the called function a Speedy.js function by adding the \"use speedyjs\" directive.",
+        code: 1000033
     }
 };

--- a/packages/compiler/src/transform/log-unknown-transform-visitor.ts
+++ b/packages/compiler/src/transform/log-unknown-transform-visitor.ts
@@ -129,6 +129,62 @@ export class LogUnknownTransformVisitor implements TransformVisitor {
         return context.visitEachChild(parenthesizedExpression);
     }
 
+    visitThisKeyword?(thisKeyword: ts.Token<ts.SyntaxKind.ThisKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(thisKeyword);
+    }
+
+    visitPropertyDeclaration?(propertyDeclaration: ts.PropertyDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(propertyDeclaration);
+    }
+
+    visitPrivateKeyword?(privateKeyword: ts.Token<ts.SyntaxKind.PrivateKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(privateKeyword);
+    }
+
+    visitConstructor?(constructor: ts.ConstructorDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(constructor);
+    }
+
+    visitArrayLiteralExpression(arrayLiteralExpression: ts.ArrayLiteralExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(arrayLiteralExpression);
+    }
+
+    visitClassDeclaration?(classDeclaration: ts.ClassDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(classDeclaration);
+    }
+
+    visitMethodDeclaration(methodDeclaration: ts.MethodDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(methodDeclaration);
+    }
+
+    visitWhileStatement?(whileStatement: ts.WhileStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(whileStatement);
+    }
+
+    visitBreakStatement?(breakStatement: ts.BreakStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(breakStatement);
+    }
+
+    visitPublicKeyword?(publicKeyword: ts.Token<ts.SyntaxKind.PublicKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(publicKeyword);
+    }
+
+    visitArrayType?(arrayType: ts.ArrayTypeNode, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(arrayType);
+    }
+
+    visitAsExpression?(asExpression: ts.AsExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(asExpression);
+    }
+
+    visitConditionalExpression?(conditionalExpression: ts.ConditionalExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(conditionalExpression);
+    }
+
+    visitContinueStatement?(continueStatement: ts.ContinueStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node> {
+        return context.visitEachChild(continueStatement);
+    }
+
     fallback<T extends ts.Node>(node: T, context: TransformVisitorContext): T {
         LOG(`Unknown Node Type ${ts.SyntaxKind[node.kind]} - ${(node.constructor as any).name}`);
         return context.visitEachChild(node);

--- a/packages/compiler/src/transform/transform-visitor.ts
+++ b/packages/compiler/src/transform/transform-visitor.ts
@@ -64,12 +64,20 @@ export interface TransformVisitor {
      */
     fallback<T extends ts.Node>(node: T, context: TransformVisitorContext): T;
 
+    visitAsExpression?(asExpression: ts.AsExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitAsyncKeyword?(asyncKeyword: ts.Token<ts.SyntaxKind.AsyncKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitArrayLiteralExpression?(arrayLiteralExpression: ts.ArrayLiteralExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitArrayType?(arrayType: ts.ArrayTypeNode, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitAwaitExpression?(awaitExpression: ts.AwaitExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitBinaryExpression?(binaryExpression: ts.BinaryExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitBlock?(block: ts.Block, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitBooleanKeyword?(booleanKeyword: ts.Token<ts.SyntaxKind.BooleanKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitBreakStatement?(breakStatement: ts.BreakStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitCallExpression?(callExpression: ts.CallExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitClassDeclaration?(classDeclaration: ts.ClassDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitConditionalExpression?(conditionalExpression: ts.ConditionalExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitConstructor?(constructor: ts.ConstructorDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitContinueStatement?(continueStatement: ts.ContinueStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitElementAccessExpression?(elementAccessExpression: ts.ElementAccessExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitExpressionStatement?(expressionStatement: ts.ExpressionStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitExportKeyword?(exportKeyword: ts.Token<ts.SyntaxKind.ExportKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
@@ -80,20 +88,26 @@ export interface TransformVisitor {
     visitIdentifier?(identifier: ts.Identifier, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitIfStatement?(ifStatement: ts.IfStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitIntKeyword?(intKeyword: ts.Token<ts.SyntaxKind.IntKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitMethodDeclaration?(methodDeclaration: ts.MethodDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitNewExpression?(newExpression: ts.NewExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitNumberKeyword?(keyword: ts.Token<ts.SyntaxKind.NumberKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitParameter?(parameter: ts.ParameterDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitParenthesizedExpression?(parenthesizedExpression: ts.ParenthesizedExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitPrivateKeyword?(privateKeyword: ts.Token<ts.SyntaxKind.PrivateKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitPublicKeyword?(publicKeyword: ts.Token<ts.SyntaxKind.PublicKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitPrefixUnaryExpression?(prefixUnaryExpression: ts.PrefixUnaryExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitPropertyAccessExpression?(propertyAccessExpression: ts.PropertyAccessExpression, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitPropertyDeclaration?(propertyDeclaration: ts.PropertyDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitReturnStatement?(returnStatement: ts.ReturnStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitSourceFile?(sourceFile: ts.SourceFile, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitStringLiteral?(stringLiteral: ts.Token<ts.SyntaxKind.StringLiteral>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitThisKeyword?(thisKeyword: ts.Token<ts.SyntaxKind.ThisKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitTrueKeyword?(trueKeyword: ts.Token<ts.SyntaxKind.TrueKeyword>, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitTypeReference?(typeReference: ts.TypeReferenceNode, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitVariableDeclaration?(variableDeclaration: ts.VariableDeclaration, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitVariableDeclarationList?(variableDeclarationList: ts.VariableDeclarationList, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
     visitVariableStatement?(variableStatement: ts.VariableStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
+    visitWhileStatement?(whileStatement: ts.WhileStatement, context: TransformVisitorContext): ts.VisitResult<ts.Node>;
 }
 
 /**

--- a/packages/compiler/src/util/speedyjs-function.ts
+++ b/packages/compiler/src/util/speedyjs-function.ts
@@ -1,0 +1,47 @@
+import * as ts from "typescript";
+
+/**
+ * tests if the passed function is a speedy js function
+ * @param fun the function to test
+ * @return {boolean} true if the function is a speedy js function
+ */
+export function isSpeedyJSFunction(fun: ts.FunctionLikeDeclaration) {
+    if (!fun.body || !isBlock(fun.body)) {
+        return false;
+    }
+
+    for (const statement of fun.body.statements) {
+        if (isPrologueDirective(statement)) {
+            if (statement.expression.text === "use speedyjs") {
+                return true;
+            }
+        } else {
+            break;
+        }
+    }
+    return false;
+}
+
+/**
+ * A speedy js function has the async modifier and contains "use speedyjs" directive
+ * @param fun the function to test
+ * @return {boolean} true if it is a speedy js entry function
+ */
+export function isSpeedyJSEntryFunction(fun: ts.FunctionLikeDeclaration): fun is ts.FunctionDeclaration {
+    return isSpeedyJSFunction(fun) &&
+        fun.kind === ts.SyntaxKind.FunctionDeclaration &&
+        !!fun.modifiers &&
+        !!fun.modifiers.find(modifier => modifier.kind === ts.SyntaxKind.AsyncKeyword);
+}
+
+interface PrologueDirective extends ts.ExpressionStatement {
+    expression: ts.StringLiteral;
+}
+
+function isPrologueDirective(node: ts.Node): node is PrologueDirective {
+    return node.kind === ts.SyntaxKind.ExpressionStatement && (node as ts.ExpressionStatement).expression.kind === ts.SyntaxKind.StringLiteral;
+}
+
+function isBlock(node: ts.Node): node is ts.Block {
+    return node.kind === ts.SyntaxKind.Block;
+}


### PR DESCRIPTION
Using Speedy.js is an explicit Opt-in. Therefore, it should
be required to mark methods and constructors with speedy.js as well.