### PR TITLE
Use `read` function of SpiderMonkey to read WASM Module

### DIFF
--- a/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
+++ b/packages/compiler/__tests__/__snapshots__/transformation.spec.ts.snap
@@ -318,6 +318,9 @@ function __moduleLoader(wasmUri, options) {
                 });
             });
         }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
+        }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
@@ -733,6 +736,9 @@ function __moduleLoader(wasmUri, options) {
                     }
                 });
             });
+        }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
         }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
@@ -1152,6 +1158,9 @@ function __moduleLoader(wasmUri, options) {
                 });
             });
         }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
+        }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
@@ -1567,6 +1576,9 @@ function __moduleLoader(wasmUri, options) {
                     }
                 });
             });
+        }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
         }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
@@ -2026,6 +2038,9 @@ function __moduleLoader(wasmUri, options) {
                 });
             });
         }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
+        }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
@@ -2442,6 +2457,9 @@ function __moduleLoader(wasmUri, options) {
                     }
                 });
             });
+        }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
         }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
@@ -2860,6 +2878,9 @@ function __moduleLoader(wasmUri, options) {
                 });
             });
         }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
+        }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
@@ -3275,6 +3296,9 @@ function __moduleLoader(wasmUri, options) {
                     }
                 });
             });
+        }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
         }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
@@ -3692,6 +3716,9 @@ function __moduleLoader(wasmUri, options) {
                 });
             });
         }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
+        }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");
         }
@@ -4107,6 +4134,9 @@ function __moduleLoader(wasmUri, options) {
                     }
                 });
             });
+        }
+        else if (typeof read !== \\"undefined\\") {
+            wasmLoaded = Promise.resolve(read(wasmUri, \\"binary\\").buffer);
         }
         else {
             throw new Error(\\"Unknown environment, can not load WASM module\\");

--- a/packages/compiler/src/code-generation/per-file/get-wasm-module-function.ts
+++ b/packages/compiler/src/code-generation/per-file/get-wasm-module-function.ts
@@ -5,6 +5,8 @@
  */
 
 declare function fetch(url: string): Promise<any>;
+declare function read(filename: string, type: "binary"): Uint8Array;
+declare function read(filename: string, type?: string): string;
 declare var window: any;
 
 interface Type {
@@ -398,6 +400,8 @@ function __moduleLoader(this: any, wasmUri: string, options: Options): ModuleLoa
                     }
                 });
             });
+        } else if (typeof read !== "undefined") { // Spidermonkey shell
+            wasmLoaded = Promise.resolve(read(wasmUri, "binary").buffer);
         } else {
             throw new Error("Unknown environment, can not load WASM module");
         }


### PR DESCRIPTION
SpiderMonkey neither supports the fetch, the process nor fs api.
 Therefore, use the read built in read function instead.