### PR TITLE
Use LLVM Config to retrieve bin dir

### DIFF
--- a/packages/compiler/scripts/binaryen-installer.js
+++ b/packages/compiler/scripts/binaryen-installer.js
@@ -21,7 +21,8 @@ function buildBinaryen(directory) {
     dependencyUtils.exec('cmake -E chdir "%s" cmake "%s"', binaryenBuildDirectory, binaryenDirectory);
     dependencyUtils.make(binaryenBuildDirectory);
 
-    return binaryenBuildDirectory;
+    // The paths needs to be relative as npm install is run in a temporary directory that changes when the installation was successful.
+    return path.relative(process.cwd(), binaryenBuildDirectory);
 }
 
 function install(directory) {

--- a/packages/compiler/scripts/install-dependencies.js
+++ b/packages/compiler/scripts/install-dependencies.js
@@ -10,14 +10,12 @@ function build() {
         fs.mkdirSync(TOOLS_DIRECTORY);
     }
 
-    // The paths needs to be relative as npm install is run in a temporary directory that changes when the installation was successful.
-    // relative paths are also useful on heroku where all dependencies need to be relative to the build directory
-    const llvm = path.relative(process.cwd(), llvmInstaller.install());
-    const binaryen = path.relative(process.cwd(), binaryenInstaller.install(TOOLS_DIRECTORY));
+    const llvmConfig = llvmInstaller.install();
+    const binaryen = binaryenInstaller.install(TOOLS_DIRECTORY);
 
     const configuration = {
         BINARYEN: binaryen,
-        LLVM: llvm
+        LLVM_CONFIG: llvmConfig
     };
 
     console.log("speedyjs-runtime configuration", configuration);

--- a/packages/compiler/scripts/llvm-installer.js
+++ b/packages/compiler/scripts/llvm-installer.js
@@ -3,7 +3,7 @@ const path = require("path");
 const dependencyUtils = require("./dependency-utils");
 
 function install() {
-    let binDir;
+    let llvmConfigPath;
 
     const configuredLLVM = process.env.LLVM_CONFIG || process.env.npm_config_LLVM_CONFIG;
 
@@ -15,14 +15,14 @@ function install() {
             throw new Error("LLVM config (" + configuredLLVM + ") reports that the WebAssembly target is missing (" + builtTargets.trim() +"). An LLVM installation with the WebAssembly target is required");
         }
 
-        binDir = dependencyUtils.execPiped("%s --bindir", configuredLLVM).trim();
+        llvmConfigPath = configuredLLVM;
     } else {
         // no explicit llvm installation set, try default
         try {
             const builtTargets = dependencyUtils.execPiped("llvm-config --targets-built").trim();
 
             if (builtTargets.indexOf("WebAssembly") !== -1) {
-                binDir = dependencyUtils.execPiped("llvm-config --bindir").trim();
+                llvmConfigPath = "llvm-config";
             } else {
                 console.warn("Default LLVM-Installation reports no WebAssembly backend (" + builtTargets + ") and is, therefore, not used.");
             }
@@ -32,13 +32,13 @@ function install() {
     }
 
     // No installation provided and default did not work, so use custom build
-    if (!binDir) {
+    if (!llvmConfigPath) {
         throw new Error("No LLVM installation with built in WebAssembly backend found. Please build LLVM from source according to https://github.com/MichaReiser/speedy.js/blob/master/doc/BUILD_LLVM_FROM_SOURCE.md and set the LLVM_CONFIG variable to the llvm-config executable.");
     }
 
-    console.log("Use llvm installation located at '" + binDir + "'.");
+    console.log("Use llvm installation located at '" + llvmConfigPath + "'.");
 
-    return binDir;
+    return llvmConfigPath;
 }
 
 module.exports = { install: install };

--- a/packages/runtime/scripts/install-dependencies.js
+++ b/packages/runtime/scripts/install-dependencies.js
@@ -3,6 +3,7 @@ const os = require("os");
 const fs = require("fs");
 const util = require("util");
 
+const dependencyUtils = require("../../compiler/scripts/dependency-utils");
 const llvmInstaller = require("../../compiler/scripts/llvm-installer");
 const binaryenInstaller = require("../../compiler/scripts/binaryen-installer");
 const emscriptenInstaller = require("./emscripten-installer");
@@ -19,7 +20,9 @@ function build() {
         fs.mkdirSync(COMPILER_TOOLS_DIRECTORY);
     }
 
-    const llvm = llvmInstaller.install(COMPILER_TOOLS_DIRECTORY);
+    const llvmConfig = llvmInstaller.install(COMPILER_TOOLS_DIRECTORY);
+    const llvm = dependencyUtils.execPiped(llvmConfig + " --bindir").trim();
+
     const binaryen = binaryenInstaller.install(COMPILER_TOOLS_DIRECTORY);
     const emscripten = emscriptenInstaller.install(TOOLS_DIRECTORY);
 


### PR DESCRIPTION
Do not resolve LLVM binary path when installing instead retrieve
the path when running the application. The reason, therefore, is that
in dynamic environments like heroku paths change between installing
and running.