### PR TITLE
Attach Node to Errors thrown during code generation

### DIFF
--- a/packages/compiler/src/code-generation/code-generators/array-literal-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/array-literal-expression-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {getArrayElementType} from "../util/types";
@@ -24,7 +24,7 @@ class ArrayLiteralExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Arra
             if (!casted) {
                 const arrayElementTypeName = context.typeChecker.typeToString(elementType);
                 const elementTypeName = context.typeChecker.typeToString(context.typeChecker.getTypeAtLocation(element));
-                throw CodeGenerationDiagnostic.implicitArrayElementCast(element, arrayElementTypeName, elementTypeName);
+                throw CodeGenerationDiagnostics.implicitArrayElementCast(element, arrayElementTypeName, elementTypeName);
             }
             elements[i] = casted.generateIR(context);
         }

--- a/packages/compiler/src/code-generation/code-generators/as-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/as-expression-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {Primitive} from "../value/primitive";
@@ -21,7 +21,7 @@ class AsExpressionCodeGenerator implements SyntaxCodeGenerator<ts.AsExpression, 
         } else if (targetType.flags & ts.TypeFlags.NumberLike) {
             castedValue = Primitive.toNumber(value, sourceType, targetType, context);
         } else {
-            throw CodeGenerationDiagnostic.unsupportedCast(node, context.typeChecker.typeToString(sourceType), context.typeChecker.typeToString(targetType));
+            throw CodeGenerationDiagnostics.unsupportedCast(node, context.typeChecker.typeToString(sourceType), context.typeChecker.typeToString(targetType));
         }
 
         return castedValue;

--- a/packages/compiler/src/code-generation/code-generators/binary-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/binary-expression-code-generator.ts
@@ -1,6 +1,6 @@
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {isMaybeObjectType, toLLVMType} from "../util/types";
@@ -393,7 +393,7 @@ class BinaryExpressionCodeGenerator implements SyntaxCodeGenerator<ts.BinaryExpr
         }
 
         if (!resultValue) {
-            throw CodeGenerationDiagnostic.unsupportedBinaryOperation(
+            throw CodeGenerationDiagnostics.unsupportedBinaryOperation(
                 binaryExpression,
                 context.typeChecker.typeToString(leftType),
                 context.typeChecker.typeToString(leftType)
@@ -453,7 +453,7 @@ class BinaryExpressionCodeGenerator implements SyntaxCodeGenerator<ts.BinaryExpr
         const leftType = context.typeChecker.getTypeAtLocation(binaryExpression.left);
         const rightType = context.typeChecker.getTypeAtLocation(binaryExpression.right);
 
-        throw CodeGenerationDiagnostic.unsupportedImplicitCastOfBinaryExpressionOperands(
+        throw CodeGenerationDiagnostics.unsupportedImplicitCastOfBinaryExpressionOperands(
             binaryExpression,
             context.typeChecker.typeToString(leftType),
             context.typeChecker.typeToString(rightType)

--- a/packages/compiler/src/code-generation/code-generators/conditional-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/conditional-expression-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {Primitive} from "../value/primitive";
@@ -25,12 +25,12 @@ class ConditionalExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Condi
         const conditionalTypeName = context.typeChecker.typeToString(conditionalType);
         if (!whenFalse) {
             const whenFalseTypeName = context.typeChecker.typeToString(whenFalseType);
-            throw CodeGenerationDiagnostic.unsupportedImplicitCastOfConditionalResult(node.whenFalse, conditionalTypeName, whenFalseTypeName);
+            throw CodeGenerationDiagnostics.unsupportedImplicitCastOfConditionalResult(node.whenFalse, conditionalTypeName, whenFalseTypeName);
         }
 
         if (!whenTrue) {
             const whenTrueTypeName = context.typeChecker.typeToString(whenTrueType);
-            throw CodeGenerationDiagnostic.unsupportedImplicitCastOfConditionalResult(node.whenTrue, conditionalTypeName, whenTrueTypeName);
+            throw CodeGenerationDiagnostics.unsupportedImplicitCastOfConditionalResult(node.whenTrue, conditionalTypeName, whenTrueTypeName);
         }
 
         const result = context.builder.createSelect(conditionBool, whenTrue.generateIR(context), whenFalse.generateIR(context), "cond");

--- a/packages/compiler/src/code-generation/code-generators/element-access-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/element-access-expression-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {ObjectIndexReference} from "../value/object-index-reference";
@@ -12,12 +12,12 @@ class ElementAccessExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Ele
 
     generate(node: ts.ElementAccessExpression, context: CodeGenerationContext): ObjectIndexReference {
         if (!node.argumentExpression) {
-            throw CodeGenerationDiagnostic.unsupportedElementAccessExpression(node);
+            throw CodeGenerationDiagnostics.unsupportedElementAccessExpression(node);
         }
 
         const argumentExpressionType = context.typeChecker.getTypeAtLocation(node.argumentExpression);
         if (!(argumentExpressionType.flags & ts.TypeFlags.IntLike)) {
-            throw CodeGenerationDiagnostic.unsupportedElementAccessExpression(node, context.typeChecker.typeToString(argumentExpressionType));
+            throw CodeGenerationDiagnostics.unsupportedElementAccessExpression(node, context.typeChecker.typeToString(argumentExpressionType));
         }
 
         const value = context.generateValue(node.expression).dereference(context);
@@ -26,7 +26,7 @@ class ElementAccessExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Ele
             return value.getIndexer(node, context);
         }
 
-        throw CodeGenerationDiagnostic.unsupportedIndexer(node);
+        throw CodeGenerationDiagnostics.unsupportedIndexer(node);
     }
 }
 

--- a/packages/compiler/src/code-generation/code-generators/first-literal-token-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/first-literal-token-code-generator.ts
@@ -1,6 +1,6 @@
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
@@ -18,7 +18,7 @@ class FirstLiteralTokenCodeGenerator implements SyntaxCodeGenerator<ts.LiteralEx
         } else if (type.flags & ts.TypeFlags.NumberLike) {
             value = llvm.ConstantFP.get(context.llvmContext, +node.text);
         } else {
-            throw CodeGenerationDiagnostic.unsupportedLiteralType(node, context.typeChecker.typeToString(type));
+            throw CodeGenerationDiagnostics.unsupportedLiteralType(node, context.typeChecker.typeToString(type));
         }
 
         return new Primitive(value, type);

--- a/packages/compiler/src/code-generation/code-generators/identifier-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/identifier-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
@@ -33,7 +33,7 @@ class IdentifierCodeGenerator implements SyntaxCodeGenerator<ts.Identifier, Valu
             }
         }
 
-        throw CodeGenerationDiagnostic.unsupportedIdentifier(identifier);
+        throw CodeGenerationDiagnostics.unsupportedIdentifier(identifier);
     }
 
     private static getFunction(symbol: ts.Symbol, identifier: ts.Identifier, context: CodeGenerationContext) {

--- a/packages/compiler/src/code-generation/code-generators/postfix-unary-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/postfix-unary-expression-code-generator.ts
@@ -1,6 +1,6 @@
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
@@ -34,7 +34,7 @@ class PostfixUnaryExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Post
         }
 
         if (!updated) {
-            throw CodeGenerationDiagnostic.unsupportedUnaryOperation(postfixUnaryExpression, context.typeChecker.typeToString(operandType));
+            throw CodeGenerationDiagnostics.unsupportedUnaryOperation(postfixUnaryExpression, context.typeChecker.typeToString(operandType));
         }
 
         context.assignValue(left, context.value(updated, operandType));

--- a/packages/compiler/src/code-generation/code-generators/prefix-unary-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/prefix-unary-expression-code-generator.ts
@@ -1,6 +1,6 @@
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {Primitive} from "../value/primitive";
@@ -65,7 +65,7 @@ class PrefixUnaryExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Prefi
         }
 
         if (!result) {
-            throw CodeGenerationDiagnostic.unsupportedUnaryOperation(node, context.typeChecker.typeToString(operandType));
+            throw CodeGenerationDiagnostics.unsupportedUnaryOperation(node, context.typeChecker.typeToString(operandType));
         }
 
         const resultValue = context.value(result, resultType);

--- a/packages/compiler/src/code-generation/code-generators/property-access-expression-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/property-access-expression-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {ClassReference} from "../value/class-reference";
@@ -17,11 +17,11 @@ class PropertyAccessExpressionCodeGenerator implements SyntaxCodeGenerator<ts.Pr
         }
 
         if (object instanceof ClassReference) {
-            throw CodeGenerationDiagnostic.unsupportedStaticProperties(propertyExpression);
+            throw CodeGenerationDiagnostics.unsupportedStaticProperties(propertyExpression);
         }
 
         // e.g. on function
-        throw CodeGenerationDiagnostic.unsupportedProperty(propertyExpression);
+        throw CodeGenerationDiagnostics.unsupportedProperty(propertyExpression);
     }
 }
 

--- a/packages/compiler/src/code-generation/code-generators/return-statement-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/return-statement-code-generator.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {TypeChecker} from "../../type-checker";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
@@ -21,7 +21,7 @@ class ReturnStatementCodeGenerator implements SyntaxCodeGenerator<ts.ReturnState
             const casted = returnValue.castImplicit(returnType, context);
 
             if (!casted) {
-                throw CodeGenerationDiagnostic.unsupportedImplicitCastOfReturnValue(
+                throw CodeGenerationDiagnostics.unsupportedImplicitCastOfReturnValue(
                     returnStatement,
                     context.typeChecker.typeToString(returnType),
                     context.typeChecker.typeToString(expressionType)

--- a/packages/compiler/src/code-generation/code-generators/string-literal-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/string-literal-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 
@@ -15,7 +15,7 @@ class StringLiteralCodeGenerator implements SyntaxCodeGenerator<ts.StringLiteral
             return;
         }
 
-        throw CodeGenerationDiagnostic.unsupportedSyntaxKind(node);
+        throw CodeGenerationDiagnostics.unsupportedSyntaxKind(node);
     }
 
     /**

--- a/packages/compiler/src/code-generation/code-generators/variable-declaration-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/variable-declaration-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 import {Allocation} from "../value/allocation";
@@ -19,7 +19,7 @@ class VariableDeclarationCodeGenerator implements SyntaxCodeGenerator<ts.Variabl
             const castedInitializer = initializer.castImplicit(type, context);
 
             if (!castedInitializer) {
-                throw CodeGenerationDiagnostic.unsupportedImplicitCast(
+                throw CodeGenerationDiagnostics.unsupportedImplicitCast(
                     variableDeclaration,
                     context.typeChecker.typeToString(type),
                     context.typeChecker.typeToString(initializerType)

--- a/packages/compiler/src/code-generation/code-generators/variable-declaration-list-code-generator.ts
+++ b/packages/compiler/src/code-generation/code-generators/variable-declaration-list-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {SyntaxCodeGenerator} from "../syntax-code-generator";
 
@@ -9,7 +9,7 @@ class VariableDeclarationListCodeGenerator implements SyntaxCodeGenerator<ts.Var
     generate(variableDeclarationList: ts.VariableDeclarationList, context: CodeGenerationContext): void {
         if ((variableDeclarationList.flags & ts.NodeFlags.Let) !== ts.NodeFlags.Let &&
             (variableDeclarationList.flags & ts.NodeFlags.Const) !== ts.NodeFlags.Const) {
-            throw CodeGenerationDiagnostic.variableDeclarationList(variableDeclarationList);
+            throw CodeGenerationDiagnostics.variableDeclarationList(variableDeclarationList);
         }
 
         context.generateChildren(variableDeclarationList);

--- a/packages/compiler/src/code-generation/default-code-generation-context.ts
+++ b/packages/compiler/src/code-generation/default-code-generation-context.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as debug from "debug";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
+import {toCodeGenerationDiagnostic} from "../code-generation-diagnostic";
 import {CompilationContext} from "../compilation-context";
 import {CodeGenerationContext} from "./code-generation-context";
 import {applyCodeGenerationContextMixin} from "./code-generation-context-mixin";
@@ -59,8 +60,12 @@ export class DefaultCodeGenerationContext implements CodeGenerationContext {
 
     generate(node: ts.Node): void | Value {
         log(`Generate node ${ts.SyntaxKind[node.kind]}`);
-        const codeGenerator = this.getCodeGenerator(node);
-        return codeGenerator.generate(node, this);
+        try {
+            const codeGenerator = this.getCodeGenerator(node);
+            return codeGenerator.generate(node, this);
+        } catch (error) {
+            throw toCodeGenerationDiagnostic(error, node);
+        }
     }
 
     registerCodeGenerator(codeGenerator: SyntaxCodeGenerator<ts.Node, Value | void>): void {

--- a/packages/compiler/src/code-generation/not-yet-implemented-code-generator.ts
+++ b/packages/compiler/src/code-generation/not-yet-implemented-code-generator.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../code-generation-diagnostic";
 
 import {CodeGenerationContext} from "./code-generation-context";
 import {FallbackCodeGenerator} from "./fallback-code-generator";
@@ -11,6 +11,6 @@ import {FallbackCodeGenerator} from "./fallback-code-generator";
 export class NotYetImplementedCodeGenerator implements FallbackCodeGenerator {
 
     generate(node: ts.Node, context: CodeGenerationContext): void {
-        throw CodeGenerationDiagnostic.unsupportedSyntaxKind(node);
+        throw CodeGenerationDiagnostics.unsupportedSyntaxKind(node);
     }
 }

--- a/packages/compiler/src/code-generation/util/types.ts
+++ b/packages/compiler/src/code-generation/util/types.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 
 /**
@@ -47,7 +47,7 @@ export function toLLVMType(type: ts.Type, context: CodeGenerationContext): llvm.
     }
 
     if (type.getSymbol() && type.getSymbol().getDeclarations().length > 0) {
-        throw CodeGenerationDiagnostic.unsupportedType(type.getSymbol().getDeclarations()[0], context.typeChecker.typeToString(type));
+        throw CodeGenerationDiagnostics.unsupportedType(type.getSymbol().getDeclarations()[0], context.typeChecker.typeToString(type));
     }
 
     throw new Error(`Unsupported type ${context.typeChecker.typeToString(type)}`);

--- a/packages/compiler/src/code-generation/value/abstract-function-reference.ts
+++ b/packages/compiler/src/code-generation/value/abstract-function-reference.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CompilationContext} from "../../compilation-context";
 import {CodeGenerationContext} from "../code-generation-context";
 import {llvmArrayValue} from "../util/llvm-array-helpers";
@@ -165,7 +165,7 @@ function toLlvmVariadicArgument(varArgs: ts.Expression[], parameter: ResolvedFun
         const varArgNode = varArgs[j];
         const castedElement = callerContext.generateValue(varArgNode).castImplicit(elementType, callerContext);
         if (!castedElement) {
-            throw CodeGenerationDiagnostic.unsupportedImplicitCastOfArgument(
+            throw CodeGenerationDiagnostics.unsupportedImplicitCastOfArgument(
                 varArgNode,
                 callerContext.typeChecker.typeToString(elementType),
                 callerContext.typeChecker.typeToString(callerContext.typeChecker.getTypeAtLocation(varArgNode))
@@ -182,7 +182,7 @@ function toLlvmArgumentValue(arg: ts.Expression, parameter: ResolvedFunctionPara
     const argumentType = callerContext.typeChecker.getTypeAtLocation(arg);
 
     if (!castedElement) {
-        throw CodeGenerationDiagnostic.unsupportedImplicitCastOfArgument(
+        throw CodeGenerationDiagnostics.unsupportedImplicitCastOfArgument(
             arg,
             callerContext.typeChecker.typeToString(parameter.type),
             callerContext.typeChecker.typeToString(argumentType)

--- a/packages/compiler/src/code-generation/value/built-in-object-reference.ts
+++ b/packages/compiler/src/code-generation/value/built-in-object-reference.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 
 import {CodeGenerationContext} from "../code-generation-context";
 import {isMaybeObjectType, toLLVMType} from "../util/types";
@@ -93,11 +93,11 @@ export abstract class BuiltInObjectReference implements ObjectReference {
      */
     protected throwUnsupportedBuiltIn(node: ts.PropertyAccessExpression | ts.ElementAccessExpression, symbol?: ts.Symbol): never {
         if (node.kind === ts.SyntaxKind.ElementAccessExpression) {
-            throw CodeGenerationDiagnostic.builtInDoesNotSupportElementAccess(node, this.typeName);
+            throw CodeGenerationDiagnostics.builtInDoesNotSupportElementAccess(node, this.typeName);
         } else if (node.kind === ts.SyntaxKind.PropertyAccessExpression) {
-            throw CodeGenerationDiagnostic.builtInPropertyNotSupported(node, this.typeName);
+            throw CodeGenerationDiagnostics.builtInPropertyNotSupported(node, this.typeName);
         } else {
-            throw CodeGenerationDiagnostic.builtInMethodNotSupported(node, this.typeName, symbol!.name);
+            throw CodeGenerationDiagnostics.builtInMethodNotSupported(node, this.typeName, symbol!.name);
         }
     }
 

--- a/packages/compiler/src/code-generation/value/math-object-reference.ts
+++ b/packages/compiler/src/code-generation/value/math-object-reference.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {ComputedObjectPropertyReferenceBuilder} from "../util/computed-object-property-reference-builder";
 import {BuiltInObjectReference} from "./built-in-object-reference";
@@ -35,7 +35,7 @@ export class MathObjectReference extends BuiltInObjectReference {
             case "max":
                 return UnresolvedMethodReference.createRuntimeMethod(this, signatures, context, { readnone: true, noUnwind: true });
             default:
-                throw CodeGenerationDiagnostic.builtInMethodNotSupported(propertyAccessExpression, "Math", symbol.name);
+                throw CodeGenerationDiagnostics.builtInMethodNotSupported(propertyAccessExpression, "Math", symbol.name);
         }
     }
 

--- a/packages/compiler/src/code-generation/value/speedy-js-class-reference.ts
+++ b/packages/compiler/src/code-generation/value/speedy-js-class-reference.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CompilationContext} from "../../compilation-context";
 import {CodeGenerationContext} from "../code-generation-context";
 import {Address} from "./address";
@@ -19,13 +19,13 @@ export class SpeedyJSClassReference extends ClassReference {
 
         const declaration = type.getSymbol().valueDeclaration as ts.ClassDeclaration;
         if (baseTypes && type.getBaseTypes().length > 0) {
-            throw CodeGenerationDiagnostic.unsupportedClassInheritance(declaration);
+            throw CodeGenerationDiagnostics.unsupportedClassInheritance(declaration);
         }
 
         if (type.objectFlags & ts.ObjectFlags.Reference) {
             const typeReference = type as ts.TypeReference;
             if (typeReference.typeArguments && typeReference.typeArguments.length > 0) {
-                throw CodeGenerationDiagnostic.unsupportedGenericClass(declaration);
+                throw CodeGenerationDiagnostics.unsupportedGenericClass(declaration);
             }
         }
 

--- a/packages/compiler/src/code-generation/value/speedyjs-function-factory.ts
+++ b/packages/compiler/src/code-generation/value/speedyjs-function-factory.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CompilationContext} from "../../compilation-context";
 import {CodeGenerationContext} from "../code-generation-context";
 import {DefaultNameMangler} from "../default-name-mangler";
@@ -13,22 +13,22 @@ import {ResolvedFunction} from "./resolved-function";
 export function verifyIsSupportedSpeedyJSFunction(declaration: ts.Declaration, context: CodeGenerationContext) {
     // tslint:disable-next-line: max-line-length
     if (!(declaration.kind === ts.SyntaxKind.FunctionDeclaration || declaration.kind === ts.SyntaxKind.MethodDeclaration || declaration.kind === ts.SyntaxKind.Constructor)) {
-        throw CodeGenerationDiagnostic.unsupportedFunctionDeclaration(declaration);
+        throw CodeGenerationDiagnostics.unsupportedFunctionDeclaration(declaration);
     }
 
     const functionDeclaration = declaration as ts.FunctionDeclaration | ts.MethodDeclaration | ts.ConstructorDeclaration;
 
     if (functionDeclaration.typeParameters && functionDeclaration.typeParameters.length > 0) {
-        throw CodeGenerationDiagnostic.unsupportedGenericFunction(functionDeclaration);
+        throw CodeGenerationDiagnostics.unsupportedGenericFunction(functionDeclaration);
     }
 
     // tslint:disable-next-line: max-line-length
     if (functionDeclaration.kind === ts.SyntaxKind.FunctionDeclaration && functionDeclaration.parent && functionDeclaration.parent.kind !== ts.SyntaxKind.SourceFile) {
-        throw CodeGenerationDiagnostic.unsupportedNestedFunctionDeclaration(functionDeclaration);
+        throw CodeGenerationDiagnostics.unsupportedNestedFunctionDeclaration(functionDeclaration);
     }
 
     if (context.typeChecker.isImplementationOfOverload(functionDeclaration)) {
-        throw CodeGenerationDiagnostic.unsupportedOverloadedFunctionDeclaration(functionDeclaration);
+        throw CodeGenerationDiagnostics.unsupportedOverloadedFunctionDeclaration(functionDeclaration);
     }
 }
 

--- a/packages/compiler/src/code-generation/value/speedyjs-object-reference.ts
+++ b/packages/compiler/src/code-generation/value/speedyjs-object-reference.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../../code-generation-diagnostic";
 import {CodeGenerationContext} from "../code-generation-context";
 import {isMaybeObjectType, toLLVMType} from "../util/types";
 import {Address} from "./address";
@@ -38,7 +38,7 @@ export class SpeedyJSObjectReference implements ObjectReference {
     }
 
     getIndexer(element: ts.ElementAccessExpression, context: CodeGenerationContext): ObjectIndexReference {
-        throw CodeGenerationDiagnostic.unsupportedIndexer(element);
+        throw CodeGenerationDiagnostics.unsupportedIndexer(element);
     }
 
     isAssignable(): false {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -2,7 +2,7 @@ import * as debug from "debug";
 import * as llvm from "llvm-node";
 import * as ts from "typescript";
 import {BuiltInSymbols} from "./built-in-symbols";
-import {CodeGenerationDiagnostic} from "./code-generation-diagnostic";
+import {CodeGenerationDiagnostics, isCodeGenerationDiagnostic} from "./code-generation-diagnostic";
 import {DefaultCodeGenerationContextFactory} from "./code-generation/default-code-generation-context-factory";
 import {NotYetImplementedCodeGenerator} from "./code-generation/not-yet-implemented-code-generator";
 import {PerFileCodeGenerator} from "./code-generation/per-file/per-file-code-generator";
@@ -96,8 +96,8 @@ export class Compiler {
 
             return { exitStatus, diagnostics: emitResult.diagnostics };
         } catch (ex) {
-            if (ex instanceof CodeGenerationDiagnostic) {
-                return { exitStatus: ts.ExitStatus.DiagnosticsPresent_OutputsSkipped, diagnostics: [ ex.toDiagnostic() ]};
+            if (isCodeGenerationDiagnostic(ex)) {
+                return { exitStatus: ts.ExitStatus.DiagnosticsPresent_OutputsSkipped, diagnostics: [ CodeGenerationDiagnostics.toDiagnostic(ex) ]};
             } else {
                 LOG(`Compilation failed`, ex);
                 throw ex;

--- a/packages/compiler/src/transform/speedyjs-transform-visitor.ts
+++ b/packages/compiler/src/transform/speedyjs-transform-visitor.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {CodeGenerationDiagnostic} from "../code-generation-diagnostic";
+import {CodeGenerationDiagnostics} from "../code-generation-diagnostic";
 import {CodeGenerator} from "../code-generation/code-generator";
 import {CompilationContext} from "../compilation-context";
 import {TypeChecker} from "../type-checker";
@@ -40,9 +40,9 @@ export class SpeedyJSTransformVisitor implements TransformVisitor {
         if (typeof symbol !== "undefined" && symbol.flags & (ts.SymbolFlags.Function | ts.SymbolFlags.Method | ts.SymbolFlags.Constructor)) {
             for (const declaration of symbol.getDeclarations() as ts.FunctionLikeDeclaration[]) {
                 if (this.inSpeedyJSFunction && !canBeCalledFromSpeedyJs(declaration)) {
-                    throw CodeGenerationDiagnostic.refereneToNonSpeedyJSFunctionFromSpeedyJS(identifier, symbol);
+                    throw CodeGenerationDiagnostics.refereneToNonSpeedyJSFunctionFromSpeedyJS(identifier, symbol);
                 } else if (!this.inSpeedyJSFunction && !canBeCalledFromJs(declaration)) {
-                    throw CodeGenerationDiagnostic.referenceToNonSpeedyJSEntryFunctionFromJS(identifier, symbol);
+                    throw CodeGenerationDiagnostics.referenceToNonSpeedyJSEntryFunctionFromJS(identifier, symbol);
                 }
             }
         }
@@ -111,20 +111,20 @@ export class SpeedyJSTransformVisitor implements TransformVisitor {
  */
 function validateSpeedyJSFunction(fun: ts.FunctionLikeDeclaration, typeChecker: TypeChecker) {
     if (!fun.name) {
-        throw CodeGenerationDiagnostic.anonymousEntryFunctionsNotSupported(fun);
+        throw CodeGenerationDiagnostics.anonymousEntryFunctionsNotSupported(fun);
     }
 
     const optional = fun.parameters.find(parameter => !!parameter.questionToken || !!parameter.dotDotDotToken);
     if (optional) {
-        throw CodeGenerationDiagnostic.optionalParametersInEntryFunctionNotSupported(optional);
+        throw CodeGenerationDiagnostics.optionalParametersInEntryFunctionNotSupported(optional);
     }
 
     if (fun.typeParameters && fun.typeParameters.length > 0) {
-        throw CodeGenerationDiagnostic.genericEntryFunctionNotSupported(fun);
+        throw CodeGenerationDiagnostics.genericEntryFunctionNotSupported(fun);
     }
 
     if (typeChecker.isImplementationOfOverload(fun)) {
-        throw CodeGenerationDiagnostic.overloadedEntryFunctionNotSupported(fun);
+        throw CodeGenerationDiagnostics.overloadedEntryFunctionNotSupported(fun);
     }
 }
 


### PR DESCRIPTION
This allows to identify the code causing the error more easily